### PR TITLE
Feature: min depth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ const normal = createInspector({ concurrency: 8 });
 
 If you have a very deep file tree and you are only interested in the top couple of levels you can specify a depth limit with the `maxDepth` option. By default there is no limit (Infinity). The minimum value is 1, which is _just_ the direct children of the target folder.
 
+Additionally if you are only interested in the results inside a subfolder then `minDepth` can be used to filter out results from the top levels. It defaults to 0 which indicates the inclusion of the root entry.
+
 ## Hidden files/folders
 
 Hidden files/folders ( ones whose name starts with a full stop ) are skipped by default, in the case of folders the children will also not be visited. The option `includeHidden` can be used to disable this behavior, ensuring all files are visited.
@@ -185,6 +187,10 @@ const ignorePermissionError = createInspector({ catch (err, location) {
 - ### InspectorOptions.maxDepth
 
   An optional positive non-zero integer which specified the maximum search depth through the folder tree. Infinity indicates no limit. Default value is Infinity.
+
+- ### InspectorOptions.minDepth
+
+  An optional positive integer which specified the minimum search depth through the folder tree. Infinity indicates no limit. 0 indicates all entries should be included. Default value is 0.
 
 - ### InspectorOptions.exclude
 

--- a/src/inspector.test.ts
+++ b/src/inspector.test.ts
@@ -192,6 +192,10 @@ describe('inspector', () => {
     expect(() => createInspector({ maxDepth: 0 })).toThrowError('Invalid maxDepth value 0. Expected either a positive non-zero integer, or Infinity.')
   });
 
+  it('does not accept overlapping maxDepth/minDepth values', () => {
+    expect(() => createInspector({ maxDepth: 2, minDepth: 3 })).toThrowError('Invalid depth range. Expected minDepth to be less than or equal to maxDepth.')
+  });
+
   it('can conditionally include folders', async () => {
     const { search } = createInspector({ includeFolders: true });
     const files = await search(ROOT);
@@ -258,7 +262,7 @@ describe('inspector', () => {
     }));
   });
 
-  it('can accept a depth limit', async() => {
+  it('can accept a max depth limit', async() => {
     const { search } = createInspector({ maxDepth: 2 });
     const files = await search(ROOT);
 
@@ -268,7 +272,17 @@ describe('inspector', () => {
     expect(files).toContainEqual(FILE_FQ_DESCRIPTION);
   });
 
-  it('can accept a depth limit of 1', async() => {
+  it('can accept a min depth limit', async() => {
+    const { search } = createInspector({ minDepth: 2 });
+    const files = await search(ROOT);
+
+    expect(files.length).toEqual(2);
+
+    expect(files).toContainEqual(FILE_PNG_DESCRIPTION);
+    expect(files).toContainEqual(FILE_TXT_DESCRIPTION);
+  });
+
+  it('can accept a max depth limit of 1', async() => {
     const { search } = createInspector({ maxDepth: 1 });
     const files = await search(ROOT);
 

--- a/src/inspector.test.ts
+++ b/src/inspector.test.ts
@@ -192,6 +192,10 @@ describe('inspector', () => {
     expect(() => createInspector({ maxDepth: 0 })).toThrowError('Invalid maxDepth value 0. Expected either a positive non-zero integer, or Infinity.')
   });
 
+  it('does not accept invalid minDepth value', () => {
+    expect(() => createInspector({ minDepth: 3.14 })).toThrowError('Invalid minDepth value 3.14. Expected either a positive integer, or Infinity.')
+  });
+
   it('does not accept overlapping maxDepth/minDepth values', () => {
     expect(() => createInspector({ maxDepth: 2, minDepth: 3 })).toThrowError('Invalid depth range. Expected minDepth to be less than or equal to maxDepth.')
   });

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -15,6 +15,7 @@ export function createInspector <T = FileInfo>(options: InspectorOptions<T> = {}
     map,
     concurrency = 8,
     maxDepth = Infinity,
+    minDepth = 0,
     catch: recover,
     includeFolders = false,
     includeHidden = false
@@ -26,6 +27,14 @@ export function createInspector <T = FileInfo>(options: InspectorOptions<T> = {}
 
   if (!isValidCount(maxDepth)) {
     throw new Error(`Invalid maxDepth value ${maxDepth}. Expected either a positive non-zero integer, or Infinity.`);
+  }
+
+  if (minDepth !== 0 && !isValidCount(minDepth)) {
+    throw new Error(`Invalid minDepth value ${minDepth}. Expected either a positive integer, or Infinity.`);
+  }
+
+  if (minDepth > maxDepth) {
+    throw new Error(`Invalid depth range. Expected minDepth to be less than or equal to maxDepth.`)
   }
 
   return {
@@ -53,6 +62,11 @@ export function createInspector <T = FileInfo>(options: InspectorOptions<T> = {}
             return; // unless we are set to include folders in the result exit before we get to the filter stage
           }
         }
+
+        if (depth < minDepth) {
+          return; // if our current depth is less than the minDepth then exit before we get to the filter stage
+        }
+
         // decide if we should include this entry in the result list
         if (!filter || await filter(info)) {
           if (map) {

--- a/src/inspector.type.ts
+++ b/src/inspector.type.ts
@@ -4,6 +4,7 @@ export interface InspectorOptions<T = FileInfo> {
   includeHidden?: boolean;
   includeFolders?: boolean;
   concurrency?: number;
+  minDepth?: number;
   maxDepth?: number;
   exclude?: (info: FileInfo) => boolean | Promise<boolean>;
   filter?: (info: FileInfo) => boolean | Promise<boolean>;


### PR DESCRIPTION
Adds a "minDepth" option to the inspector that omits any entries above a certain depth. This can in theory be done using a filter but being done separately like this reduces the complexity and allows for more optimisation in the search procedure.