### PR TITLE
Feature: include only folders in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ There are several ways to manipulate the results as they are being generated wit
 
 ### Filtering
 
-Before each item is added to the results it can optionally be omitted using a 'filter' function. If 'includeFolders' is true then folders will be passed to the filter function, but the filter will not prevent the children of the folder from being visited.
+Before each item is added to the results it can optionally be omitted using a 'filter' function. If folders are included in the output then they will be passed to the filter function, but the filter will not prevent the children of the folder from being visited.
 
 ```typescript
 import { createInspector } from 'fs-inspect';
@@ -55,7 +55,7 @@ async function main() {
 
 ### Excluding
 
-When a folder is visited an optional 'exclude' function can be used to indicate that the children of the folder should be skipped, which has obvious performance advantages if you wish to skip large parts of the file tree. If 'includeFolders' is true then excluded folders will not be included in the results, so you will not have to use 'filter' to skip them.
+When a folder is visited an optional 'exclude' function can be used to indicate that the children of the folder should be skipped, which has obvious performance advantages if you wish to skip large parts of the file tree. If folders are included in the output then excluded folders will not be included in the results, so you will not have to use 'filter' to skip them.
 
 ```typescript
 import { createInspector } from 'fs-inspect';
@@ -119,7 +119,7 @@ const normal = createInspector({ concurrency: 8 });
 
 ## Depth limiting
 
-If you have a very deep file tree and you are only interested in the top couple of levels you can specify a depth limit with the `maxDepth` option. By default there is no limit (Infinity). The minimum value is 1, which is _just_ the direct children of the target folder.
+If you have a very deep file tree and you are only interested in the top couple of levels you can specify a depth limit with the `maxDepth` option. By default there is no limit (Infinity). The minimum value is 1, which is *just* the direct children of the target folder.
 
 ## Hidden files/folders
 
@@ -127,11 +127,11 @@ Hidden files/folders ( ones whose name starts with a full stop ) are skipped by 
 
 ## Folders in output
 
-Folders are not added to the output by default, you can include them using the `includeFolders` option.
+Folders are not added to the output by default, you can include them by setting the `type` option to `all` or `folders`. These include files and folders, or just folders respectively.
 
 ## Root entry
 
-If the target location for the search is a file, then only that file will be included in the output. Providing that it passes any filters you have specified. If it's a folder and `includeFolders` is set then it will be included in the output. In both cases the relative path will be an empty string, indicating that it is the root of the tree.
+If the target location for the search is a file, then only that file will be included in the output. Providing that it passes any filters you have specified. If it's a folder and are included in the output normally then it will be included in the output. In both cases the relative path will be an empty string, indicating that it is the root of the tree.
 
 ## Error recovery
 
@@ -174,9 +174,13 @@ const ignorePermissionError = createInspector({ catch (err, location) {
 
   An optional boolean flag that causes files and folders whose name begins with full stop should be visited while searching. Default value is false.
 
-- ### InspectorOptions.includeFolders
+- ### InspectorOptions.type
   
-  An optional boolean flag that causes folders to be included in the output. Default value is false.
+  An optional string which indicates if `'files'`, `'folders'` or `'all'` should be included in the output. Default value is `'files'`.
+
+- ### InspectorOptions.includeFolders
+
+  **Depreciated** optional boolean flag that indicates that folders should be included in the output. Use `type: 'all'` instead.
 
 - ### InspectorOptions.concurrency
   

--- a/src/inspector.test.ts
+++ b/src/inspector.test.ts
@@ -208,6 +208,49 @@ describe('inspector', () => {
     expect(files).toContainEqual(FOLDER_N_DESCRIPTION);
   });
 
+  it('type: "all" includes folders and files', async () => {
+    const { search } = createInspector({ type: 'all' });
+    const files = await search(ROOT);
+
+    expect(files.length).toEqual(7);
+    expect(files).toContainEqual(ROOT_DESCRIPTION);
+
+    expect(files).toContainEqual(FILE_TXT_DESCRIPTION);
+    expect(files).toContainEqual(FILE_FQ_DESCRIPTION);
+    expect(files).toContainEqual(FILE_PNG_DESCRIPTION);
+
+    expect(files).toContainEqual(FOLDER_A_DESCRIPTION);
+    expect(files).toContainEqual(FOLDER_B_DESCRIPTION);
+    expect(files).toContainEqual(FOLDER_N_DESCRIPTION);
+  });
+
+  it('type: "folders" includes only folders', async () => {
+    const { search } = createInspector({ type: 'folders' });
+    const files = await search(ROOT);
+
+    expect(files.length).toEqual(4);
+    expect(files).toContainEqual(ROOT_DESCRIPTION);
+
+    expect(files).toContainEqual(FOLDER_A_DESCRIPTION);
+    expect(files).toContainEqual(FOLDER_B_DESCRIPTION);
+    expect(files).toContainEqual(FOLDER_N_DESCRIPTION);
+  });
+
+  it('type: "files" includes only files', async () => {
+    const { search } = createInspector({ type: 'files' });
+    const files = await search(ROOT);
+
+    expect(files.length).toEqual(3);
+
+    expect(files).toContainEqual(FILE_TXT_DESCRIPTION);
+    expect(files).toContainEqual(FILE_FQ_DESCRIPTION);
+    expect(files).toContainEqual(FILE_PNG_DESCRIPTION);
+  });
+
+  it('does not allow both type and includeFolder to be specified', () => {
+    expect(() => createInspector({ type: 'all', includeFolders: true })).toThrow('Clashing arguments "type" and "includeFolder" specified. Use "type: all" to include files and folders in your output.')
+  });
+
   it('can conditionally include hidden files/folders', async () => {
     const { search } = createInspector({ includeFolders: true, includeHidden: true });
     const files = await search(ROOT);

--- a/src/inspector.type.ts
+++ b/src/inspector.type.ts
@@ -2,7 +2,11 @@ import type { FileInfo } from "./FileInfo.type";
 
 export interface InspectorOptions<T = FileInfo> {
   includeHidden?: boolean;
+  /** 
+   * @deprecated use `type: 'all'` instead
+   */
   includeFolders?: boolean;
+  type?: 'files' | 'folders' | 'all';
   concurrency?: number;
   maxDepth?: number;
   exclude?: (info: FileInfo) => boolean | Promise<boolean>;


### PR DESCRIPTION
This change depreciated the `includeFolder` option in favour of a `type` option which can be the values `'files' | 'folders' | 'all'`. This new option allows you to only include folders in the output. While technically possible by using a filter this separates the concept and allows for possible optimisation of the search procedure.