### PR TITLE
Improvement: use dirent and avoid stat where possible

### DIFF
--- a/src/FileInfo.ts
+++ b/src/FileInfo.ts
@@ -23,10 +23,6 @@ export async function makeFileInfo(root: string, relative: string): Promise<File
   };
 }
 
-export function isFileInfo(entry: BasicFileInfo): entry is FileInfo {
-  return 'size' in entry;
-}
-
 export async function extendFileInfo(entry: BasicFileInfo): Promise<FileInfo> {
   const { base, name, ext } = path.parse(entry.absolute);
   const info = await fs.promises.stat(entry.absolute);

--- a/src/FileInfo.ts
+++ b/src/FileInfo.ts
@@ -23,6 +23,10 @@ export async function makeFileInfo(root: string, relative: string): Promise<File
   };
 }
 
+export function isFileInfo(entry: BasicFileInfo): entry is FileInfo {
+  return 'size' in entry;
+}
+
 export async function extendFileInfo(entry: BasicFileInfo): Promise<FileInfo> {
   const { base, name, ext } = path.parse(entry.absolute);
   const info = await fs.promises.stat(entry.absolute);

--- a/src/FileInfo.ts
+++ b/src/FileInfo.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 
-import type { FileInfo } from './FileInfo.type';
+import type { FileInfo, BasicFileInfo } from './FileInfo.type';
 
 export async function makeFileInfo(root: string, relative: string): Promise<FileInfo> {
   const absolute = path.join(root, relative);
@@ -15,6 +15,21 @@ export async function makeFileInfo(root: string, relative: string): Promise<File
     relative,
     absolute,
     size: isDirectory ? 0 : size,
+    base,
+    name,
+    ext,
+    created,
+    modified,
+  };
+}
+
+export async function extendFileInfo(entry: BasicFileInfo): Promise<FileInfo> {
+  const { base, name, ext } = path.parse(entry.absolute);
+  const info = await fs.promises.stat(entry.absolute);
+  const { size, birthtimeMs: created, mtimeMs: modified } = info;
+  return {
+    ...entry,
+    size: entry.isDirectory ? 0 : size,
     base,
     name,
     ext,

--- a/src/FileInfo.type.ts
+++ b/src/FileInfo.type.ts
@@ -1,8 +1,11 @@
-export interface FileInfo {
+export interface BasicFileInfo {
   isDirectory: boolean;
   relative: string;
   absolute: string;
   hidden: boolean;
+}
+
+export interface FileInfo extends BasicFileInfo {
   size: number;
   base: string;
   name: string;

--- a/src/inspector.test.ts
+++ b/src/inspector.test.ts
@@ -379,4 +379,7 @@ describe('inspector', () => {
     expect(files).toContainEqual(fileFQ);
     expect(files).toContainEqual(filePNG);
   });
+
+  it.todo('calls recover for an error reading the entry point');
+  it.todo('propogates the error when entry point fails and no recover function is specified');
 });

--- a/src/inspector.test.ts
+++ b/src/inspector.test.ts
@@ -380,6 +380,20 @@ describe('inspector', () => {
     expect(files).toContainEqual(filePNG);
   });
 
-  it.todo('calls recover for an error reading the entry point');
-  it.todo('propogates the error when entry point fails and no recover function is specified');
+  it('calls recover for an error reading the entry point', async() => {
+    const inspector = createInspector({
+      catch(err) {
+        expect(((err as { code: string }).code === 'ENOENT'));
+      }
+    });
+
+    const result = await inspector.search(path.join(rootFolder, 'ghost'));
+
+    expect(result).toStrictEqual([]);
+  });
+
+  it('propogates the error when entry point fails and no recover function is specified', async() => {
+    const inspector = createInspector({});
+    await expect(inspector.search(path.join(rootFolder, 'ghost'))).rejects.toThrow(/^ENOENT/);
+  });
 });

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -61,15 +61,16 @@ export function createInspector <T = FileInfo>(options: InspectorOptions<T> = {}
           return; // this is a "hidden" dot file/folder, skip it unless we've been configured to include it
         }
         if (basicInfo.isDirectory) {
-          // if we have reached the max depth then don't visit the contents of this folder
-          if (depth < maxDepth) {
-            if (exclude) {
-              fullInfo = await extendFileInfo(basicInfo);
-              if (await exclude(fullInfo)) {
-                // if the exclusion folder indicates we should ignore this folder then exit here
-                return;
-              }
+          if (exclude) {
+            fullInfo = await extendFileInfo(basicInfo);
+            if (await exclude(fullInfo)) {
+              // if the exclusion folder indicates we should ignore this folder then exit here
+              return;
             }
+          }
+
+          // if we have reached the max depth then don't visit the contents of this folder
+          if (depth < maxDepth) {  
             // add all the entries of the folder to the queue
             for (const entry of await fs.promises.readdir(basicInfo.absolute, { withFileTypes: true })) {
               const child = {
@@ -82,6 +83,7 @@ export function createInspector <T = FileInfo>(options: InspectorOptions<T> = {}
               add(child, depth + 1);
             }
           }
+          
           if (includeTypes === 'files') {
             return; // unless we are set to include folders in the result exit before we get to the filter stage
           }

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -57,22 +57,22 @@ export function createInspector <T = FileInfo>(options: InspectorOptions<T> = {}
       const processEntry = async (basicInfo: BasicFileInfo, depth: number) => {
         const info = await extendFileInfo(basicInfo);
 
-        if (info.hidden && !includeHidden) {
+        if (basicInfo.hidden && !includeHidden) {
           return; // this is a "hidden" dot file/folder, skip it unless we've been configured to include it
         }
-        if (info.isDirectory) {
+        if (basicInfo.isDirectory) {
           // if we have reached the max depth then don't visit the contents of this folder
           if (depth < maxDepth) {
             if (exclude && await exclude(info)) {
               return; // if the exclusion folder indicates we should ignore this folder then exit here
             }
             // add all the entries of the folder to the queue
-            for (const entry of await fs.promises.readdir(info.absolute, { withFileTypes: true })) {
+            for (const entry of await fs.promises.readdir(basicInfo.absolute, { withFileTypes: true })) {
               const child = {
                 isDirectory: entry.isDirectory(),
                 hidden: entry.name.startsWith('.'),
-                relative: path.join(info.relative, entry.name),
-                absolute: path.join(info.absolute, entry.name),
+                relative: path.join(basicInfo.relative, entry.name),
+                absolute: path.join(basicInfo.absolute, entry.name),
               };
 
               add(child, depth + 1);

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -55,7 +55,7 @@ export function createInspector <T = FileInfo>(options: InspectorOptions<T> = {}
       const results: T[] = [];
 
       const processEntry = async (basicInfo: BasicFileInfo, depth: number) => {
-        let info: FileInfo | null = null;
+        let fullInfo: FileInfo | null = null;
 
         if (basicInfo.hidden && !includeHidden) {
           return; // this is a "hidden" dot file/folder, skip it unless we've been configured to include it
@@ -64,8 +64,8 @@ export function createInspector <T = FileInfo>(options: InspectorOptions<T> = {}
           // if we have reached the max depth then don't visit the contents of this folder
           if (depth < maxDepth) {
             if (exclude) {
-              info = await extendFileInfo(basicInfo);
-              if (await exclude(info)) {
+              fullInfo = await extendFileInfo(basicInfo);
+              if (await exclude(fullInfo)) {
                 // if the exclusion folder indicates we should ignore this folder then exit here
                 return;
               }
@@ -96,18 +96,18 @@ export function createInspector <T = FileInfo>(options: InspectorOptions<T> = {}
         }
 
         // we'll need the full info object for filtering/output
-        if (info === null) {
-          info = await extendFileInfo(basicInfo);
+        if (fullInfo === null) {
+          fullInfo = await extendFileInfo(basicInfo);
         }
 
         // decide if we should include this entry in the result list
         if (filter) { 
-          if (!await filter(info)) {
+          if (!await filter(fullInfo)) {
             return;
           }
         }
 
-        const output = map ? await map(info) : info;
+        const output = map ? await map(fullInfo) : fullInfo;
         results.push(output as unknown as T);
       };
 

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -92,14 +92,14 @@ export function createInspector <T = FileInfo>(options: InspectorOptions<T> = {}
         }
 
         // decide if we should include this entry in the result list
-        if (!filter || await filter(info)) {
-          if (map) {
-            results.push(await map(info));
-          } else {
-            // if map is not specified T will be FileInfo
-            results.push(info as unknown as T);
+        if (filter) { 
+          if (!await filter(info)) {
+            return;
           }
         }
+
+        const output = map ? await map(info) : info;
+        results.push(output as unknown as T);
       };
 
       const { add, complete } = queue({ concurrency, fn: processEntry, recover });


### PR DESCRIPTION
In the existing model all entries are `stat`d to determine if they are a file/folder so they can be processed correctly. When we do that we also generate all the additional information we _might_ require.

The intention of this change is to utilise the newer mode of readdir to output a list of Dirent objects, which contain basic details including the type of the entry and its name. By doing this we can avoid calling stat for each entry. We will still need to call it for anything handed to the consumer, so that we maintain compatibility. When using `exclude`, `filter`, `map` and outputing entries. However, we may be able to avoid utilising it for the majority of entries.

Hopefully this will prove to be a performance improvement for complex directory trees.