### PR TITLE
Introduce simplemode to the inspector

### DIFF
--- a/src/inspector.type.ts
+++ b/src/inspector.type.ts
@@ -1,6 +1,7 @@
-import type { FileInfo } from './FileInfo.type';
+import type { BasicFileInfo, FileInfo } from './FileInfo.type';
 
-export interface InspectorOptions<T = FileInfo> {
+
+export interface CoreInspectorOptions {
   includeHidden?: boolean;
   /** 
    * @deprecated use `type: 'all'` instead
@@ -10,11 +11,24 @@ export interface InspectorOptions<T = FileInfo> {
   concurrency?: number;
   minDepth?: number;
   maxDepth?: number;
+  catch?: (error: unknown, location: string) => void | Promise<void>; 
+}
+
+export interface SimpleInspectorOptions<T = BasicFileInfo> extends CoreInspectorOptions {
+  simpleMode: true; 
+  exclude?: (info: BasicFileInfo) => boolean | Promise<boolean>;
+  filter?: (info: BasicFileInfo) => boolean | Promise<boolean>;
+  map?: (info: BasicFileInfo) => T | Promise<T>;
+}
+
+export interface NormalInspectorOptions<T = FileInfo> extends CoreInspectorOptions {
+  simpleMode?: false; 
   exclude?: (info: FileInfo) => boolean | Promise<boolean>;
   filter?: (info: FileInfo) => boolean | Promise<boolean>;
   map?: (info: FileInfo) => T | Promise<T>;
-  catch?: (error: unknown, location: string) => void | Promise<void>; 
 }
+
+export type InspectorOptions<T = BasicFileInfo> = NormalInspectorOptions<T> | SimpleInspectorOptions<T>;
 
 export interface Inspector<T = FileInfo> {
   search: (location: string) => Promise<T[]>;


### PR DESCRIPTION
Introduces the "simplemode" flag which skips the stat operation entirely.

Currently this solution is not passing compile time checks for some reason. But some adjustment might be in order anyway as the search function is getting rather complex with multiple levels of conditional code.